### PR TITLE
Parameterize git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which feat
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" OFF)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 
+set(TRITON_REPO_ORGANIZATION "https://github.com/triton-inference-server" CACHE STRING "Git repository to pull from")
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
@@ -61,19 +62,19 @@ include(FetchContent)
 
 FetchContent_Declare(
   repo-common
-  GIT_REPOSITORY https://github.com/triton-inference-server/common.git
+  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/common.git
   GIT_TAG ${TRITON_COMMON_REPO_TAG}
   GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-core
-  GIT_REPOSITORY https://github.com/triton-inference-server/core.git
+  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
   GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-backend
-  GIT_REPOSITORY https://github.com/triton-inference-server/backend.git
+  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/backend.git
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
   GIT_SHALLOW ON
 )


### PR DESCRIPTION
This PR parameterizes the github repository used when building. 

Related internal PRs:
Server: https://github.com/triton-inference-server/server/pull/6934
Core: https://github.com/triton-inference-server/core/pull/332
Backend: https://github.com/triton-inference-server/backend/pull/96
Checksum repository agent: https://github.com/triton-inference-server/checksum_repository_agent/pull/10
Dali backend: https://github.com/triton-inference-server/dali_backend/pull/228
Identity backend: https://github.com/triton-inference-server/identity_backend/pull/29
Local cache: https://github.com/triton-inference-server/local_cache/pull/12
Onnxruntime backend: https://github.com/triton-inference-server/onnxruntime_backend/pull/244
Openvino backend: https://github.com/triton-inference-server/openvino_backend/pull/68
pytorch backend: https://github.com/triton-inference-server/pytorch_backend/pull/124
Redis cache: https://github.com/triton-inference-server/redis_cache/pull/14
Square backend: https://github.com/triton-inference-server/square_backend/pull/18
Tensorflow backend: https://github.com/triton-inference-server/tensorflow_backend/pull/101
Tensorrt backend: https://github.com/triton-inference-server/tensorrt_backend/pull/81
Python backend:https://github.com/triton-inference-server/python_backend/pull/341
Client: https://github.com/triton-inference-server/client/pull/485

Related third party PRs:
https://github.com/triton-inference-server/server/pull/6668